### PR TITLE
Export num_traits dependency as a public module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 
 //! This crate implements functions to search in a graph.
 
-extern crate num_traits;
+pub extern crate num_traits;
 
 mod astar;
 mod bfs;


### PR DESCRIPTION
As this concern was exposed in this [SO question](https://stackoverflow.com/q/44876113/1233251), it is preferable that `num_traits` is re-exported from your crate, thus allowing users to use `num_traits` without having to add a compatible version on their own.