### PR TITLE
Added new benchmarks

### DIFF
--- a/benches/bfs.rs
+++ b/benches/bfs.rs
@@ -3,7 +3,7 @@
 extern crate pathfinding;
 extern crate test;
 
-use pathfinding::{bfs, dijkstra};
+use pathfinding::{astar, bfs, dfs, dijkstra, fringe};
 use test::Bencher;
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -28,22 +28,116 @@ fn neighbours(pt: &Pt) -> Vec<Pt> {
     if 0 < pt.x {
         ret.push(Pt::new(pt.x - 1, pt.y))
     }
-    if pt.x < 128 {
+    if pt.x < 64 {
         ret.push(Pt::new(pt.x + 1, pt.y))
     }
     if 0 < pt.y {
         ret.push(Pt::new(pt.x, pt.y - 1))
     }
-    if pt.y < 128 {
+    if pt.y < 64 {
         ret.push(Pt::new(pt.x, pt.y + 1))
     }
     ret
 }
 
 #[bench]
+fn corner_to_corner_astar(b: &mut Bencher) {
+    b.iter(|| {
+        assert_ne!(
+            astar(
+                &Pt::new(0, 0),
+                |n| neighbours(n).into_iter().map(|n| (n, 1)),
+                |n| (64.0 - n.x as f32).hypot(64.0 - n.y as f32) as usize,
+                |n| n.x == 64 && n.y == 64,
+            ),
+            None
+        )
+    })
+}
+
+#[bench]
+fn corner_to_corner_bfs(b: &mut Bencher) {
+    b.iter(|| {
+        assert_ne!(
+            bfs(
+                &Pt::new(0, 0),
+                |n| neighbours(n),
+                |n| n.x == 64 && n.y == 64,
+            ),
+            None
+        )
+    })
+}
+
+#[bench]
+fn corner_to_corner_dfs(b: &mut Bencher) {
+    b.iter(|| {
+        assert_ne!(
+            dfs(
+                Pt::new(0, 0),
+                |n| neighbours(n),
+                |n| n.x == 64 && n.y == 64,
+            ),
+            None
+        )
+    })
+}
+
+#[bench]
+fn corner_to_corner_dijkstra(b: &mut Bencher) {
+    b.iter(|| {
+        assert_ne!(
+            dijkstra(
+                &Pt::new(0, 0),
+                |n| neighbours(n).into_iter().map(|n| (n, 1)),
+                |n| n.x == 64 && n.y == 64,
+            ),
+            None
+        )
+    });
+}
+
+#[bench]
+fn corner_to_corner_fringe(b: &mut Bencher) {
+    b.iter(|| {
+        assert_ne!(
+            fringe(
+                &Pt::new(0, 0),
+                |n| neighbours(n).into_iter().map(|n| (n, 1)),
+                |n| (64.0 - n.x as f32).hypot(64.0 - n.y as f32) as usize,
+                |n| n.x == 64 && n.y == 64,
+            ),
+            None
+        )
+    })
+}
+
+#[bench]
+fn no_path_astar(b: &mut Bencher) {
+    b.iter(|| {
+        assert_eq!(
+            astar(
+                &Pt::new(2, 3),
+                |n| neighbours(n).into_iter().map(|n| (n, 1)),
+                |_| 1,
+                |_| false,
+            ),
+            None
+        )
+    })
+}
+
+#[bench]
 fn no_path_bfs(b: &mut Bencher) {
     b.iter(|| {
-        assert_eq!(bfs(&Pt::new(2, 3), |n| neighbours(n), |_| false), None)
+        assert_eq!(
+            bfs(
+                &Pt::new(2, 3),
+                |n| neighbours(n),
+                |_| false,
+            ),
+            None
+        )
     });
 }
 
@@ -59,4 +153,19 @@ fn no_path_dijkstra(b: &mut Bencher) {
             None
         )
     });
+}
+
+#[bench]
+fn no_path_fringe(b: &mut Bencher) {
+    b.iter(|| {
+        assert_eq!(
+            fringe(
+                &Pt::new(2, 3),
+                |n| neighbours(n).into_iter().map(|n| (n, 1)),
+                |_| 1,
+                |_| false,
+            ),
+            None
+        )
+    })
 }


### PR DESCRIPTION
This adds a new 'corner-to-corner' benchmark for all algorithms, and adds the 'no-path' for all algorithms except `dfs`, which enters an infinite loop. I also reduced the map size from 128x128 to 64x64 to speed things up and avoid a stack-oveflow with `corner_to_corner_dfs`.