### PR TITLE
Use stricter dependency on ndarray

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 
 [dependencies]
 fixedbitset = { version = "0.1", optional = true }
-ndarray = { version = "0.10", optional = true }
+ndarray = { version = "^0.10.7", optional = true }
 num-traits = "0.1"
 
 [dev-dependencies]


### PR DESCRIPTION
ndarray 0.10.7 is necessary to be able to parse the trailing
comma in test sources.