### PR TITLE
Attempt #3 at astar_bag

### DIFF
--- a/src/astar.rs
+++ b/src/astar.rs
@@ -142,9 +142,12 @@ where
 }
 
 #[derive(Eq, Hash, PartialEq)]
-struct PathNode<N> where N: Clone {
+struct PathNode<N>
+where
+    N: Clone,
+{
     node: Rc<N>,
-    parent: Option<Rc<PathNode<N>>>
+    parent: Option<Rc<PathNode<N>>>,
 }
 
 /// Compute all shortest paths using the [A* search
@@ -168,6 +171,7 @@ struct PathNode<N> where N: Clone {
 ///
 /// Each path comprises both the start and an end node. Note that while every path shares the same
 /// start node, different paths may have different end nodes.
+
 pub fn astar_bag<N, C, FN, IN, FH, FS>(
     start: &N,
     neighbours: FN,
@@ -187,15 +191,18 @@ where
     to_see.push(SmallestCostHolder {
         estimated_cost: heuristic(start),
         cost: Zero::zero(),
-        payload: Rc::new(PathNode{node: Rc::new(start.clone()), parent: None})
+        payload: Rc::new(PathNode {
+            node: Rc::new(start.clone()),
+            parent: None,
+        }),
     });
     let mut lowest_cost = HashMap::new();
     let mut min_cost = None;
-    while let Some(SmallestCostHolder{
+    while let Some(SmallestCostHolder {
         cost,
         estimated_cost,
-        payload}
-    ) = to_see.pop()
+        payload,
+    }) = to_see.pop()
     {
         let pn: &PathNode<N> = Rc::borrow(&payload);
         if let Some(mc) = min_cost {
@@ -223,18 +230,21 @@ where
 
                 let nrc = Rc::new(neighbour);
                 match lowest_cost.entry(Rc::clone(&nrc)) {
-                    Vacant(e) => { e.insert(new_cost); }
-                    Occupied(mut e) => {
-                        if *e.get() > new_cost {
-                            e.insert(new_cost);
-                        }
+                    Vacant(e) => {
+                        e.insert(new_cost);
                     }
+                    Occupied(mut e) => if *e.get() > new_cost {
+                        e.insert(new_cost);
+                    },
                 }
 
                 to_see.push(SmallestCostHolder {
                     estimated_cost: new_predicted_cost,
                     cost: new_cost,
-                    payload: Rc::new(PathNode{node: nrc, parent: Some(Rc::clone(&payload))})
+                    payload: Rc::new(PathNode {
+                        node: nrc,
+                        parent: Some(Rc::clone(&payload)),
+                    }),
                 });
             }
         }
@@ -242,7 +252,9 @@ where
     (out, min_cost.unwrap_or_else(Zero::zero))
 }
 
-fn mk_path<N>(mut pl: &Rc<PathNode<N>>) -> Vec<N> where N: Clone
+fn mk_path<N>(mut pl: &Rc<PathNode<N>>) -> Vec<N>
+where
+    N: Clone,
 {
     let mut path = Vec::new();
     loop {
@@ -251,7 +263,7 @@ fn mk_path<N>(mut pl: &Rc<PathNode<N>>) -> Vec<N> where N: Clone
         path.push(n.clone());
         match cur.parent {
             Some(ref p) => pl = p,
-            None => break
+            None => break,
         }
     }
     path.reverse();

--- a/tests/pathfinding.rs
+++ b/tests/pathfinding.rs
@@ -142,6 +142,47 @@ mod ex2 {
     }
 
     #[test]
+    fn astar_bag_path_single_ok() {
+        const GOAL: (usize, usize) = (6, 3);
+        let counter = RefCell::new(0);
+        let neighbours_counter = |n: &(usize, usize)| {
+            *counter.borrow_mut() += 1;
+            neighbours(n)
+        };
+        let (paths, cost) = astar_bag(
+            &(2, 3),
+            neighbours_counter,
+            |n| distance(n, &GOAL),
+            |n| n == &GOAL,
+        );
+        assert_eq!(cost, 8);
+        assert_eq!(paths.len(), 1);
+        assert!(paths.iter().all(|path| path.iter().all(|&(nx, ny)| OPEN[ny][nx])));
+        assert_eq!(*counter.borrow(), 18);
+    }
+
+    #[test]
+    fn astar_bag_path_multiple_ok() {
+        const GOAL: (usize, usize) = (7, 3);
+        let counter = RefCell::new(0);
+        let neighbours_counter = |n: &(usize, usize)| {
+            *counter.borrow_mut() += 1;
+            neighbours(n)
+        };
+        let (paths, cost) = astar_bag(
+            &(2, 3),
+            neighbours_counter,
+            |n| distance(n, &GOAL),
+            |n| n == &GOAL,
+        );
+        assert_eq!(cost, 9);
+        println!("{:?}", paths);
+        assert_eq!(paths.len(), 3);
+        assert!(paths.iter().all(|path| path.iter().all(|&(nx, ny)| OPEN[ny][nx])));
+        assert_eq!(*counter.borrow(), 22);
+    }
+
+    #[test]
     fn idastar_path_ok() {
         const GOAL: (usize, usize) = (6, 3);
         let counter = RefCell::new(0);

--- a/tests/pathfinding.rs
+++ b/tests/pathfinding.rs
@@ -157,7 +157,11 @@ mod ex2 {
         );
         assert_eq!(cost, 8);
         assert_eq!(paths.len(), 1);
-        assert!(paths.iter().all(|path| path.iter().all(|&(nx, ny)| OPEN[ny][nx])));
+        assert!(
+            paths
+                .iter()
+                .all(|path| path.iter().all(|&(nx, ny)| OPEN[ny][nx]))
+        );
         assert_eq!(*counter.borrow(), 18);
     }
 
@@ -178,7 +182,11 @@ mod ex2 {
         assert_eq!(cost, 9);
         println!("{:?}", paths);
         assert_eq!(paths.len(), 3);
-        assert!(paths.iter().all(|path| path.iter().all(|&(nx, ny)| OPEN[ny][nx])));
+        assert!(
+            paths
+                .iter()
+                .all(|path| path.iter().all(|&(nx, ny)| OPEN[ny][nx]))
+        );
         assert_eq!(*counter.borrow(), 22);
     }
 


### PR DESCRIPTION
This is a new attempt at an `astar_bag` function. It fixes the problems noted by the `astar_bag_path_multiple_ok` test. It does this by using a completely different internal structure: the easiest way I've found (and I tried a few!) seems to be to use `Rc`s to store the chain of a node and its parents. This also enables an interesting trade-off: if users are pathfinding over a complex node data-structure, this PR uses fewer `clones` of nodes than before, but at the expense of cloning `Rc`s. It entirely comes down to the relative cost of cloning `Rc` and `N` as to whether this is worth it or not... I've put one not-strictly-necessary instance of this in a separate commit, which can be removed if that's thought best.

Unfortunately I haven't been able to work out how to reuse this code in `astar`, as it changes how often nodes are visited (since we no longer stop after the first success, there are inevitably more visits made; whether this PR makes the minimal number of visits is something that's above my pay grade). However, I have kept the tests you wrote as a commit with you as author.

The good news is that this seems to work really well for the cases I need. But this is subtly different in style to `astar` and the other pathfinding functions, and (assuming `astar_bag` is correct!) it's your call as to whether this is something you want to merge or not.