### PR TITLE
Use ordermap in astar, bfs, and fringe

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ readme = "README.md"
 fixedbitset = "0.1"
 itertools = "0.7"
 num-traits = "0.1"
+ordermap = "0.3.2"
 
 [dev-dependencies]
 lazy_static = "0.2"

--- a/src/astar.rs
+++ b/src/astar.rs
@@ -1,5 +1,5 @@
 use ordermap::OrderMap;
-use ordermap::Entry::{Vacant, Occupied};
+use ordermap::Entry::{Occupied, Vacant};
 use num_traits::Zero;
 use std::collections::{BinaryHeap, HashSet};
 use std::cmp::Ordering;

--- a/src/astar.rs
+++ b/src/astar.rs
@@ -329,7 +329,7 @@ impl<K: Ord, P> Ord for SmallestCostHolder<K, P> {
 #[derive(Clone)]
 pub struct AstarSolution<N> {
     sinks: Vec<usize>,
-    parents: OrderMap<N, Vec<usize>>,
+    parents: Vec<(N, Vec<usize>)>,
     current: Vec<Vec<usize>>,
     terminated: bool,
 }
@@ -361,11 +361,11 @@ impl<N: Clone + Eq + Hash> AstarSolution<N> {
     }
 
     fn node(&self, i: usize) -> &N {
-        self.parents.get_index(i).unwrap().0
+        &self.parents[i].0
     }
 
     fn parents(&self, i: usize) -> &Vec<usize> {
-        self.parents.get_index(i).unwrap().1
+        &self.parents[i].1
     }
 }
 

--- a/src/fringe.rs
+++ b/src/fringe.rs
@@ -1,7 +1,10 @@
 use num_traits::{Bounded, Zero};
-use std::collections::{HashMap, VecDeque};
+use ordermap::OrderMap;
+use ordermap::Entry::{Occupied, Vacant};
+use std::collections::VecDeque;
 use std::hash::Hash;
 use std::mem;
+use std::usize;
 use super::reverse_path;
 
 /// Compute a shortest path using the [Fringe search
@@ -86,43 +89,52 @@ where
 {
     let mut now = VecDeque::new();
     let mut later = VecDeque::new();
-    let mut costs: HashMap<N, C> = HashMap::new();
-    let mut parents: HashMap<N, N> = HashMap::new();
+    let mut parents: OrderMap<N, (usize, C)> = OrderMap::new();
     let mut flimit = heuristic(start);
-    now.push_back(start.clone());
-    costs.insert(start.clone(), Zero::zero());
+    now.push_back(0);
+    parents.insert(start.clone(), (usize::MAX, Zero::zero()));
 
     loop {
         if now.is_empty() {
             return None;
         }
         let mut fmin = C::max_value();
-        while let Some(node) = now.pop_front() {
-            let g = costs[&node];
-            let f = g + heuristic(&node);
-            if f > flimit {
-                if f < fmin {
-                    fmin = f;
-                }
-                later.push_back(node);
-                continue;
-            }
-            if success(&node) {
-                return Some((reverse_path(&parents, node), g));
-            }
-            for (neighbour, cost) in neighbours(&node) {
-                let g_neighbour = g + cost;
-                if let Some(&old_g) = costs.get(&neighbour) {
-                    if old_g <= g_neighbour {
-                        continue;
+        while let Some(i) = now.pop_front() {
+            let (g, neighbours) = {
+                let (node, &(_, g)) = parents.get_index(i).unwrap();
+                let f = g + heuristic(&node);
+                if f > flimit {
+                    if f < fmin {
+                        fmin = f;
                     }
+                    later.push_back(i);
+                    continue;
                 }
-                if !remove(&mut later, &neighbour) {
-                    remove(&mut now, &neighbour);
+                if success(node) {
+                    let path = reverse_path(&parents, |&(p, _)| p, i);
+                    return Some((path, g));
                 }
-                now.push_front(neighbour.clone());
-                costs.insert(neighbour.clone(), g_neighbour);
-                parents.insert(neighbour, node.clone());
+                (g, neighbours(&node))
+            };
+            for (neighbour, cost) in neighbours {
+                let g_neighbour = g + cost;
+                let n; // index for neighbour
+                match parents.entry(neighbour) {
+                    Vacant(e) => {
+                        n = e.index();
+                        e.insert((i, g_neighbour));
+                    }
+                    Occupied(e) => if e.get().1 > g_neighbour {
+                        n = e.index();
+                        e.insert((i, g_neighbour));
+                    } else {
+                        continue;
+                    },
+                }
+                if !remove(&mut later, &n) {
+                    remove(&mut now, &n);
+                }
+                now.push_front(n);
             }
         }
         mem::swap(&mut now, &mut later);

--- a/src/fringe.rs
+++ b/src/fringe.rs
@@ -102,7 +102,7 @@ where
         while let Some(i) = now.pop_front() {
             let (g, neighbours) = {
                 let (node, &(_, g)) = parents.get_index(i).unwrap();
-                let f = g + heuristic(&node);
+                let f = g + heuristic(node);
                 if f > flimit {
                     if f < fmin {
                         fmin = f;
@@ -114,7 +114,7 @@ where
                     let path = reverse_path(&parents, |&(p, _)| p, i);
                     return Some((path, g));
                 }
-                (g, neighbours(&node))
+                (g, neighbours(node))
             };
             for (neighbour, cost) in neighbours {
                 let g_neighbour = g + cost;


### PR DESCRIPTION
`OrderMap` is basically a `HashMap` that preserves insertion order.
That property isn't directly relevant to these algorithms, but it does
enable the very nice ability to do lookups directly by index, without
any hashing.

So in this commit, we now map to parents by their `usize` index, rather
than a whole clone of the node.  Many calls to `N::clone()` are avoided,
and hashing is only required for `insert`/`entry`, using `get_index` to
retrieve nodes the rest of the time.

The benefits are pretty good for the `algos` benchmark:

    name                       master ns/iter  ordermap ns/iter  diff ns/iter   diff %  speedup
    corner_to_corner_astar     44,816          24,973                 -19,843  -44.28%   x 1.79
    corner_to_corner_bfs       690,052         547,510               -142,542  -20.66%   x 1.26
    corner_to_corner_dfs       6,805,933       5,668,594           -1,137,339  -16.71%   x 1.20
    corner_to_corner_dijkstra  1,118,175       755,852               -362,323  -32.40%   x 1.48
    corner_to_corner_fringe    65,784          32,280                 -33,504  -50.93%   x 2.04
    corner_to_corner_idastar   21,134          20,805                    -329   -1.56%   x 1.02
    no_path_astar              981,337         757,752               -223,585  -22.78%   x 1.30
    no_path_bfs                692,944         553,116               -139,828  -20.18%   x 1.25
    no_path_dijkstra           984,072         751,608               -232,464  -23.62%   x 1.31
    no_path_fringe             1,442,798       742,887               -699,911  -48.51%   x 1.94

But it's **much** better for the `algos-fill` benchmark:

    name                       master ns/iter  ordermap ns/iter  diff ns/iter   diff %  speedup
    corner_to_corner_astar     192,819         67,694                -125,125  -64.89%   x 2.85
    corner_to_corner_bfs       4,538,152       2,130,992           -2,407,160  -53.04%   x 2.13
    corner_to_corner_dfs       14,790,089      16,145,929           1,355,840    9.17%   x 0.92
    corner_to_corner_dijkstra  7,195,432       2,372,080           -4,823,352  -67.03%   x 3.03
    corner_to_corner_fringe    216,080         67,508                -148,572  -68.76%   x 3.20
    corner_to_corner_idastar   39,047          38,435                    -612   -1.57%   x 1.02
    no_path_astar              5,529,616       2,361,610           -3,168,006  -57.29%   x 2.34
    no_path_bfs                4,493,729       2,133,594           -2,360,135  -52.52%   x 2.11
    no_path_dijkstra           5,565,605       2,349,389           -3,216,216  -57.79%   x 2.37
    no_path_fringe             7,319,658       2,374,175           -4,945,483  -67.56%   x 3.08