### PR TITLE
Accept FnMut closures, instead of just Fn

### DIFF
--- a/src/astar.rs
+++ b/src/astar.rs
@@ -76,17 +76,17 @@ use super::reverse_path;
 /// ```
 pub fn astar<N, C, FN, IN, FH, FS>(
     start: &N,
-    neighbours: FN,
-    heuristic: FH,
-    success: FS,
+    mut neighbours: FN,
+    mut heuristic: FH,
+    mut success: FS,
 ) -> Option<(Vec<N>, C)>
 where
     N: Eq + Hash + Clone,
     C: Zero + Ord + Copy,
-    FN: Fn(&N) -> IN,
+    FN: FnMut(&N) -> IN,
     IN: IntoIterator<Item = (N, C)>,
-    FH: Fn(&N) -> C,
-    FS: Fn(&N) -> bool,
+    FH: FnMut(&N) -> C,
+    FS: FnMut(&N) -> bool,
 {
     let mut to_see = BinaryHeap::new();
     to_see.push(SmallestCostHolder {
@@ -166,17 +166,17 @@ where
 /// start node, different paths may have different end nodes.
 pub fn astar_bag<N, C, FN, IN, FH, FS>(
     start: &N,
-    neighbours: FN,
-    heuristic: FH,
-    success: FS,
+    mut neighbours: FN,
+    mut heuristic: FH,
+    mut success: FS,
 ) -> Option<(AstarSolution<N>, C)>
 where
     N: Eq + Hash + Clone,
     C: Zero + Ord + Copy,
-    FN: Fn(&N) -> IN,
+    FN: FnMut(&N) -> IN,
     IN: IntoIterator<Item = (N, C)>,
-    FH: Fn(&N) -> C,
-    FS: Fn(&N) -> bool,
+    FH: FnMut(&N) -> C,
+    FS: FnMut(&N) -> bool,
 {
     let mut to_see = BinaryHeap::new();
     let mut min_cost = None;
@@ -287,10 +287,10 @@ pub fn astar_bag_collect<N, C, FN, IN, FH, FS>(
 where
     N: Eq + Hash + Clone,
     C: Zero + Ord + Copy,
-    FN: Fn(&N) -> IN,
+    FN: FnMut(&N) -> IN,
     IN: IntoIterator<Item = (N, C)>,
-    FH: Fn(&N) -> C,
-    FS: Fn(&N) -> bool,
+    FH: FnMut(&N) -> C,
+    FS: FnMut(&N) -> bool,
 {
     astar_bag(start, neighbours, heuristic, success)
         .map(|(solutions, cost)| (solutions.collect(), cost))

--- a/src/bfs.rs
+++ b/src/bfs.rs
@@ -61,12 +61,12 @@ use super::reverse_path;
 ///                  |&p| p == GOAL);
 /// assert_eq!(result.expect("no path found").len(), 5);
 /// ```
-pub fn bfs<N, FN, IN, FS>(start: &N, neighbours: FN, success: FS) -> Option<Vec<N>>
+pub fn bfs<N, FN, IN, FS>(start: &N, mut neighbours: FN, mut success: FS) -> Option<Vec<N>>
 where
     N: Eq + Hash + Clone,
-    FN: Fn(&N) -> IN,
+    FN: FnMut(&N) -> IN,
     IN: IntoIterator<Item = N>,
-    FS: Fn(&N) -> bool,
+    FS: FnMut(&N) -> bool,
 {
     let mut to_see = VecDeque::new();
     let mut parents: OrderMap<N, usize> = OrderMap::new();

--- a/src/connected_components.rs
+++ b/src/connected_components.rs
@@ -116,10 +116,10 @@ where
 ///
 /// This function returns a list of sets of nodes forming disjoint connected
 /// sets.
-pub fn connected_components<N, FN, IN>(starts: &[N], neighbours: FN) -> Vec<HashSet<N>>
+pub fn connected_components<N, FN, IN>(starts: &[N], mut neighbours: FN) -> Vec<HashSet<N>>
 where
     N: Clone + Hash + Eq,
-    FN: Fn(&N) -> IN,
+    FN: FnMut(&N) -> IN,
     IN: IntoIterator<Item = N>,
 {
     components(&starts

--- a/src/dfs.rs
+++ b/src/dfs.rs
@@ -37,27 +37,27 @@
 /// assert_eq!(dfs(1, |&n| vec![n*n, n+1].into_iter().filter(|&x| x <= 17), |&n| n == 17),
 ///            Some(vec![1, 2, 4, 16, 17]));
 /// ```
-pub fn dfs<N, FN, IN, FS>(start: N, neighbours: FN, success: FS) -> Option<Vec<N>>
+pub fn dfs<N, FN, IN, FS>(start: N, mut neighbours: FN, mut success: FS) -> Option<Vec<N>>
 where
     N: Eq,
-    FN: Fn(&N) -> IN,
+    FN: FnMut(&N) -> IN,
     IN: IntoIterator<Item = N>,
-    FS: Fn(&N) -> bool,
+    FS: FnMut(&N) -> bool,
 {
     let mut path = vec![start];
-    if step(&mut path, &neighbours, &success) {
+    if step(&mut path, &mut neighbours, &mut success) {
         Some(path)
     } else {
         None
     }
 }
 
-fn step<N, FN, IN, FS>(path: &mut Vec<N>, neighbours: &FN, success: &FS) -> bool
+fn step<N, FN, IN, FS>(path: &mut Vec<N>, neighbours: &mut FN, success: &mut FS) -> bool
 where
     N: Eq,
-    FN: Fn(&N) -> IN,
+    FN: FnMut(&N) -> IN,
     IN: IntoIterator<Item = N>,
-    FS: Fn(&N) -> bool,
+    FS: FnMut(&N) -> bool,
 {
     if success(path.last().unwrap()) {
         true

--- a/src/dijkstra.rs
+++ b/src/dijkstra.rs
@@ -64,9 +64,9 @@ pub fn dijkstra<N, C, FN, IN, FS>(start: &N, neighbours: FN, success: FS) -> Opt
 where
     N: Eq + Hash + Clone,
     C: Zero + Ord + Copy,
-    FN: Fn(&N) -> IN,
+    FN: FnMut(&N) -> IN,
     IN: IntoIterator<Item = (N, C)>,
-    FS: Fn(&N) -> bool,
+    FS: FnMut(&N) -> bool,
 {
     let zero = Zero::zero();
     astar(start, neighbours, |_| zero, success)

--- a/src/fringe.rs
+++ b/src/fringe.rs
@@ -75,17 +75,17 @@ use super::reverse_path;
 /// ```
 pub fn fringe<N, C, FN, IN, FH, FS>(
     start: &N,
-    neighbours: FN,
-    heuristic: FH,
-    success: FS,
+    mut neighbours: FN,
+    mut heuristic: FH,
+    mut success: FS,
 ) -> Option<(Vec<N>, C)>
 where
     N: Eq + Hash + Clone,
     C: Bounded + Zero + Ord + Copy,
-    FN: Fn(&N) -> IN,
+    FN: FnMut(&N) -> IN,
     IN: IntoIterator<Item = (N, C)>,
-    FH: Fn(&N) -> C,
-    FS: Fn(&N) -> bool,
+    FH: FnMut(&N) -> C,
+    FS: FnMut(&N) -> bool,
 {
     let mut now = VecDeque::new();
     let mut later = VecDeque::new();

--- a/src/idastar.rs
+++ b/src/idastar.rs
@@ -70,17 +70,17 @@ use std::hash::Hash;
 
 pub fn idastar<N, C, FN, IN, FH, FS>(
     start: &N,
-    neighbours: FN,
-    heuristic: FH,
-    success: FS,
+    mut neighbours: FN,
+    mut heuristic: FH,
+    mut success: FS,
 ) -> Option<(Vec<N>, C)>
 where
     N: Eq + Hash + Clone,
     C: Zero + Ord + Copy,
-    FN: Fn(&N) -> IN,
+    FN: FnMut(&N) -> IN,
     IN: IntoIterator<Item = (N, C)>,
-    FH: Fn(&N) -> C,
-    FS: Fn(&N) -> bool,
+    FH: FnMut(&N) -> C,
+    FS: FnMut(&N) -> bool,
 {
     let mut bound = heuristic(start);
     let mut path = vec![start.clone()];
@@ -89,9 +89,9 @@ where
             &mut path,
             Zero::zero(),
             bound,
-            &neighbours,
-            &heuristic,
-            &success,
+            &mut neighbours,
+            &mut heuristic,
+            &mut success,
         ) {
             Path::Found(path, cost) => return Some((path, cost)),
             Path::Minimum(min) => {
@@ -115,17 +115,17 @@ fn search<N, C, FN, IN, FH, FS>(
     path: &mut Vec<N>,
     cost: C,
     bound: C,
-    neighbours: &FN,
-    heuristic: &FH,
-    success: &FS,
+    neighbours: &mut FN,
+    heuristic: &mut FH,
+    success: &mut FS,
 ) -> Path<N, C>
 where
     N: Eq + Hash + Clone,
     C: Zero + Ord + Copy,
-    FN: Fn(&N) -> IN,
+    FN: FnMut(&N) -> IN,
     IN: IntoIterator<Item = (N, C)>,
-    FH: Fn(&N) -> C,
-    FS: Fn(&N) -> bool,
+    FH: FnMut(&N) -> C,
+    FS: FnMut(&N) -> bool,
 {
     let neighbs = {
         let start = &path[path.len() - 1];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,10 +35,10 @@ pub use topological_sort::*;
 use ordermap::OrderMap;
 use std::hash::Hash;
 
-fn reverse_path<N, V, F>(parents: &OrderMap<N, V>, parent: F, start: usize) -> Vec<N>
+fn reverse_path<N, V, F>(parents: &OrderMap<N, V>, mut parent: F, start: usize) -> Vec<N>
 where
     N: Eq + Hash + Clone,
-    F: Fn(&V) -> usize,
+    F: FnMut(&V) -> usize,
 {
     let path = itertools::unfold(start, |i| {
         parents.get_index(*i).map(|(node, value)| {

--- a/src/topological_sort.rs
+++ b/src/topological_sort.rs
@@ -33,10 +33,10 @@ use std::hash::Hash;
 ///                               |&n| (n+1..10).take(2).chain(std::iter::once(9)));
 ///  assert_eq!(sorted, Err(9));
 /// ```
-pub fn topological_sort<N, FN, IN>(nodes: &[N], successors: FN) -> Result<Vec<N>, N>
+pub fn topological_sort<N, FN, IN>(nodes: &[N], mut successors: FN) -> Result<Vec<N>, N>
 where
     N: Eq + Hash + Clone,
-    FN: Fn(&N) -> IN,
+    FN: FnMut(&N) -> IN,
     IN: IntoIterator<Item = N>,
 {
     let mut unmarked: HashSet<N> = nodes.iter().cloned().collect::<HashSet<_>>();
@@ -47,7 +47,7 @@ where
         temp.clear();
         visit(
             &node,
-            &successors,
+            &mut successors,
             &mut unmarked,
             &mut marked,
             &mut temp,
@@ -59,7 +59,7 @@ where
 
 fn visit<N, FN, IN>(
     node: &N,
-    successors: &FN,
+    successors: &mut FN,
     unmarked: &mut HashSet<N>,
     marked: &mut HashSet<N>,
     temp: &mut HashSet<N>,
@@ -67,7 +67,7 @@ fn visit<N, FN, IN>(
 ) -> Result<(), N>
 where
     N: Eq + Hash + Clone,
-    FN: Fn(&N) -> IN,
+    FN: FnMut(&N) -> IN,
     IN: IntoIterator<Item = N>,
 {
     unmarked.remove(node);

--- a/tests/connected-components.rs
+++ b/tests/connected-components.rs
@@ -47,7 +47,9 @@ fn empty_components() {
 
 #[test]
 fn basic_connected_components() {
+    let mut counter = 0;
     let c = connected_components(&[1, 4], |&n| {
+        counter += 1;
         if n % 2 == 0 {
             vec![2, 4, 6, 8]
         } else {
@@ -57,4 +59,5 @@ fn basic_connected_components() {
     assert_eq!(c.len(), 2);
     assert_eq!(c[0].clone().into_iter().sorted(), vec![1, 3, 5, 7]);
     assert_eq!(c[1].clone().into_iter().sorted(), vec![2, 4, 6, 8]);
+    assert_eq!(counter, 2);
 }

--- a/tests/pathfinding.rs
+++ b/tests/pathfinding.rs
@@ -87,7 +87,6 @@ mod ex1 {
 mod ex2 {
 
     use pathfinding::*;
-    use std::cell::RefCell;
 
     const MAZE: &str = "\
 #########
@@ -127,33 +126,31 @@ mod ex2 {
     #[test]
     fn astar_path_ok() {
         const GOAL: (usize, usize) = (6, 3);
-        let counter = RefCell::new(0);
-        let neighbours_counter = |n: &(usize, usize)| {
-            *counter.borrow_mut() += 1;
-            neighbours(n)
-        };
+        let mut counter = 0;
         let (path, cost) = astar(
             &(2, 3),
-            neighbours_counter,
+            |n| {
+                counter += 1;
+                neighbours(n)
+            },
             |n| distance(n, &GOAL),
             |n| n == &GOAL,
         ).expect("path not found");
         assert_eq!(cost, 8);
         assert!(path.iter().all(|&(nx, ny)| OPEN[ny][nx]));
-        assert_eq!(*counter.borrow(), 11);
+        assert_eq!(counter, 11);
     }
 
     #[test]
     fn astar_bag_path_single_ok() {
         const GOAL: (usize, usize) = (6, 3);
-        let counter = RefCell::new(0);
-        let neighbours_counter = |n: &(usize, usize)| {
-            *counter.borrow_mut() += 1;
-            neighbours(n)
-        };
+        let mut counter = 0;
         let (paths, cost) = astar_bag_collect(
             &(2, 3),
-            neighbours_counter,
+            |n| {
+                counter += 1;
+                neighbours(n)
+            },
             |n| distance(n, &GOAL),
             |n| n == &GOAL,
         ).unwrap();
@@ -164,20 +161,19 @@ mod ex2 {
                 .iter()
                 .all(|path| path.iter().all(|&(nx, ny)| OPEN[ny][nx]))
         );
-        assert_eq!(*counter.borrow(), 15);
+        assert_eq!(counter, 15);
     }
 
     #[test]
     fn astar_bag_path_multiple_ok() {
         const GOAL: (usize, usize) = (7, 3);
-        let counter = RefCell::new(0);
-        let neighbours_counter = |n: &(usize, usize)| {
-            *counter.borrow_mut() += 1;
-            neighbours(n)
-        };
+        let mut counter = 0;
         let (paths, cost) = astar_bag_collect(
             &(2, 3),
-            neighbours_counter,
+            |n| {
+                counter += 1;
+                neighbours(n)
+            },
             |n| distance(n, &GOAL),
             |n| n == &GOAL,
         ).unwrap();
@@ -188,60 +184,60 @@ mod ex2 {
                 .iter()
                 .all(|path| path.iter().all(|&(nx, ny)| OPEN[ny][nx]))
         );
-        assert_eq!(*counter.borrow(), 18);
+        assert_eq!(counter, 18);
     }
 
     #[test]
     fn idastar_path_ok() {
         const GOAL: (usize, usize) = (6, 3);
-        let counter = RefCell::new(0);
-        let neighbours_counter = |n: &(usize, usize)| {
-            *counter.borrow_mut() += 1;
-            neighbours(n)
-        };
+        let mut counter = 0;
         let (path, cost) = idastar(
             &(2, 3),
-            neighbours_counter,
+            |n| {
+                counter += 1;
+                neighbours(n)
+            },
             |n| distance(n, &GOAL),
             |n| n == &GOAL,
         ).expect("path not found");
         assert_eq!(cost, 8);
         assert!(path.iter().all(|&(nx, ny)| OPEN[ny][nx]));
-        assert_eq!(*counter.borrow(), 18);
+        assert_eq!(counter, 18);
     }
 
     #[test]
     fn fringe_path_ok() {
         const GOAL: (usize, usize) = (6, 3);
-        let counter = RefCell::new(0);
-        let neighbours_counter = |n: &(usize, usize)| {
-            *counter.borrow_mut() += 1;
-            neighbours(n)
-        };
+        let mut counter = 0;
         let (path, cost) = fringe(
             &(2, 3),
-            neighbours_counter,
+            |n| {
+                counter += 1;
+                neighbours(n)
+            },
             |n| distance(n, &GOAL),
             |n| n == &GOAL,
         ).expect("path not found");
         assert_eq!(cost, 8);
         assert!(path.iter().all(|&(nx, ny)| OPEN[ny][nx]));
-        assert_eq!(*counter.borrow(), 14);
+        assert_eq!(counter, 14);
     }
 
     #[test]
     fn dijkstra_path_ok() {
         const GOAL: (usize, usize) = (6, 3);
-        let counter = RefCell::new(0);
-        let neighbours_counter = |n: &(usize, usize)| {
-            *counter.borrow_mut() += 1;
-            neighbours(n)
-        };
-        let (path, cost) =
-            dijkstra(&(2, 3), neighbours_counter, |n| n == &GOAL).expect("path not found");
+        let mut counter = 0;
+        let (path, cost) = dijkstra(
+            &(2, 3),
+            |n| {
+                counter += 1;
+                neighbours(n)
+            },
+            |n| n == &GOAL
+        ).expect("path not found");
         assert_eq!(cost, 8);
         assert!(path.iter().all(|&(nx, ny)| OPEN[ny][nx]));
-        assert_eq!(*counter.borrow(), 20);
+        assert_eq!(counter, 20);
     }
 
     #[test]

--- a/tests/topological_sort.rs
+++ b/tests/topological_sort.rs
@@ -5,7 +5,6 @@ extern crate rand;
 use itertools::Itertools;
 use pathfinding::topological_sort as tsort;
 use rand::Rng;
-use std::sync::RwLock;
 
 #[test]
 fn empty() {
@@ -42,9 +41,9 @@ fn complexity() {
     let mut rng = rand::OsRng::new().unwrap();
     let mut ints = (1..1000).collect_vec();
     rng.shuffle(&mut ints);
-    let requested = RwLock::new(0);
+    let mut requested = 0;
     let result = tsort(&ints, |&n| {
-        *requested.write().unwrap() += 1;
+        requested += 1;
         if n < 999 {
             vec![n + 1]
         } else {
@@ -52,5 +51,5 @@ fn complexity() {
         }
     });
     assert_eq!(result, Ok((1..1000).collect_vec()));
-    assert_eq!(*requested.read().unwrap(), 999);
+    assert_eq!(requested, 999);
 }


### PR DESCRIPTION
If the pathfinding APIs accept `FnMut` closures, this gives the user more
flexibility, as their closures can mutate some of their captured state.
`FnMut` is a supertrait of `Fn`, so existing use cases are not affected by
this change.

The effect internally is that such closures can't be shared in multiple
places simultaneously, since calling an `FnMut` requires exclusive access.
None of the current implementations have a problem with this; they just
needed to update to mutable bindings.  (That's an internal detail, not an
API change.)

A few tests were using counters in `RefCell` or `RwLock`, and those can now
be mutated directly, captured in `FnMut` closures.