### PR TITLE
Add a dummy dependency to fix a "cargo -Z minimal-version" problem

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,9 @@ movingai = "1.0.0"
 noisy_float = "0.1.9"
 rand = "0.7.0"
 rand_xorshift = "0.2.0"
+# Not a real dependency, but needed since crossbeam-utils 0.6.5
+# does not compile anymore as of 2020-04-29.
+rayon = "1.3.0"
 
 [[bench]]
 name = "algos"


### PR DESCRIPTION
The `criterion` crate does not check that it can be configured with
`cargo -Z minimal-version` and thus indicates incorrect
(as in "not strict enough") dependencies in its `Cargo.toml`.

By forcing the use of a later version of `rayon`
(which is used by `criterion`), we prevent dragging in a
non-compiling version of `crossbeam-utils`.