### PR TITLE
Remove building badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # pathfinding
 
-[![Build Status](https://travis-ci.org/samueltardieu/pathfinding.svg?branch=master)](https://travis-ci.org/samueltardieu/pathfinding)
 [![Current Version](https://img.shields.io/crates/v/pathfinding.svg)](https://crates.io/crates/pathfinding)
 [![Documentation](https://docs.rs/pathfinding/badge.svg)](https://docs.rs/pathfinding)
 [![License: Apache-2.0/MIT](https://img.shields.io/crates/l/pathfinding.svg)](#license)


### PR DESCRIPTION
Thanks to bors, it always builds (or it is not merged).
