### PR TITLE
Use faster rustc-hash hasher for IndexMap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ fixedbitset = "0.4.0"
 itertools = "0.9.0"
 num-traits = "0.2.6"
 indexmap = "1.0.2"
+rustc-hash = "1.1.0"
 
 [dev-dependencies]
 criterion = { version = "0.3.4", features = ["html_reports"] }

--- a/src/directed/astar.rs
+++ b/src/directed/astar.rs
@@ -2,7 +2,6 @@
 //! algorithm](https://en.wikipedia.org/wiki/A*_search_algorithm).
 
 use indexmap::map::Entry::{Occupied, Vacant};
-use indexmap::IndexMap;
 use num_traits::Zero;
 use std::cmp::Ordering;
 use std::collections::{BinaryHeap, HashSet};
@@ -10,6 +9,7 @@ use std::hash::Hash;
 use std::usize;
 
 use super::reverse_path;
+use crate::directed::FxIndexMap;
 
 /// Compute a shortest path using the [A* search
 /// algorithm](https://en.wikipedia.org/wiki/A*_search_algorithm).
@@ -97,7 +97,7 @@ where
         cost: Zero::zero(),
         index: 0,
     });
-    let mut parents: IndexMap<N, (usize, C)> = IndexMap::new();
+    let mut parents: FxIndexMap<N, (usize, C)> = FxIndexMap::default();
     parents.insert(start.clone(), (usize::max_value(), Zero::zero()));
     while let Some(SmallestCostHolder { cost, index, .. }) = to_see.pop() {
         let successors = {
@@ -188,7 +188,7 @@ where
         cost: Zero::zero(),
         index: 0,
     });
-    let mut parents: IndexMap<N, (HashSet<usize>, C)> = IndexMap::new();
+    let mut parents: FxIndexMap<N, (HashSet<usize>, C)> = FxIndexMap::default();
     parents.insert(start.clone(), (HashSet::new(), Zero::zero()));
     while let Some(SmallestCostHolder {
         cost,

--- a/src/directed/bfs.rs
+++ b/src/directed/bfs.rs
@@ -2,12 +2,12 @@
 //! algorithm](https://en.wikipedia.org/wiki/Breadth-first_search).
 
 use indexmap::map::Entry::Vacant;
-use indexmap::IndexMap;
 use std::collections::{HashSet, VecDeque};
 use std::hash::Hash;
 use std::usize;
 
 use super::reverse_path;
+use crate::directed::FxIndexMap;
 
 /// Compute a shortest path using the [breadth-first search
 /// algorithm](https://en.wikipedia.org/wiki/Breadth-first_search).
@@ -90,7 +90,7 @@ where
         return Some(vec![start.clone()]);
     }
     let mut to_see = VecDeque::new();
-    let mut parents: IndexMap<N, usize> = IndexMap::new();
+    let mut parents: FxIndexMap<N, usize> = FxIndexMap::default();
     to_see.push_back(0);
     parents.insert(start.clone(), usize::max_value());
     while let Some(i) = to_see.pop_front() {

--- a/src/directed/dijkstra.rs
+++ b/src/directed/dijkstra.rs
@@ -2,7 +2,6 @@
 //! algorithm](https://en.wikipedia.org/wiki/Dijkstra's_algorithm).
 
 use indexmap::map::Entry::{Occupied, Vacant};
-use indexmap::IndexMap;
 use num_traits::Zero;
 use std::cmp::Ordering;
 use std::collections::{BinaryHeap, HashMap};
@@ -10,6 +9,7 @@ use std::hash::Hash;
 use std::usize;
 
 use super::reverse_path;
+use crate::directed::FxIndexMap;
 
 /// Compute a shortest path using the [Dijkstra search
 /// algorithm](https://en.wikipedia.org/wiki/Dijkstra's_algorithm).
@@ -171,7 +171,7 @@ fn run_dijkstra<N, C, FN, IN, FS>(
     start: &N,
     successors: &mut FN,
     stop: &mut FS,
-) -> (IndexMap<N, (usize, C)>, Option<usize>)
+) -> (FxIndexMap<N, (usize, C)>, Option<usize>)
 where
     N: Eq + Hash + Clone,
     C: Zero + Ord + Copy,
@@ -184,7 +184,7 @@ where
         cost: Zero::zero(),
         index: 0,
     });
-    let mut parents: IndexMap<N, (usize, C)> = IndexMap::new();
+    let mut parents: FxIndexMap<N, (usize, C)> = FxIndexMap::default();
     parents.insert(start.clone(), (usize::max_value(), Zero::zero()));
     let mut target_reached = None;
     while let Some(SmallestHolder { cost, index }) = to_see.pop() {

--- a/src/directed/fringe.rs
+++ b/src/directed/fringe.rs
@@ -2,8 +2,8 @@
 //! algorithm](https://en.wikipedia.org/wiki/Fringe_search).
 
 use super::reverse_path;
+use crate::directed::FxIndexMap;
 use indexmap::map::Entry::{Occupied, Vacant};
-use indexmap::IndexMap;
 use num_traits::{Bounded, Zero};
 use std::collections::VecDeque;
 use std::hash::Hash;
@@ -94,7 +94,7 @@ where
 {
     let mut now = VecDeque::new();
     let mut later = VecDeque::new();
-    let mut parents: IndexMap<N, (usize, C)> = IndexMap::new();
+    let mut parents: FxIndexMap<N, (usize, C)> = FxIndexMap::default();
     let mut flimit = heuristic(start);
     now.push_back(0);
     parents.insert(start.clone(), (usize::max_value(), Zero::zero()));

--- a/src/directed/mod.rs
+++ b/src/directed/mod.rs
@@ -13,10 +13,13 @@ pub mod topological_sort;
 pub mod yen;
 
 use indexmap::IndexMap;
-use std::hash::Hash;
+use rustc_hash::FxHasher;
+use std::hash::{BuildHasherDefault, Hash};
+
+type FxIndexMap<K, V> = IndexMap<K, V, BuildHasherDefault<FxHasher>>;
 
 #[allow(clippy::needless_collect)]
-fn reverse_path<N, V, F>(parents: &IndexMap<N, V>, mut parent: F, start: usize) -> Vec<N>
+fn reverse_path<N, V, F>(parents: &FxIndexMap<N, V>, mut parent: F, start: usize) -> Vec<N>
 where
     N: Eq + Hash + Clone,
     F: FnMut(&V) -> usize,


### PR DESCRIPTION
IndexMap's default hasher is cryptographically-secure, which is completely unnecessary for pathfinding. Using the fxhash hasher, I get around 10%-55% improvements where bigger maps have better performance.

All tests pass(except the codejam tests, but they fail without the change as well), and all benchmarks are either faster or unchanged.