### PR TITLE
Use tuples instead of tuples ref for matrix index

### DIFF
--- a/src/directed/edmonds_karp.rs
+++ b/src/directed/edmonds_karp.rs
@@ -371,7 +371,7 @@ impl<C: Copy + Zero + Signed + Eq + Ord + Bounded> EdmondsKarp<C> for SparseCapa
         let mut result = Self::new(size, source, sink);
         for from in 0..size {
             for to in 0..size {
-                let capacity = capacities[&(from, to)];
+                let capacity = capacities[(from, to)];
                 if capacity > Zero::zero() {
                     result.set_capacity(from, to, capacity);
                 }
@@ -514,11 +514,11 @@ impl<C: Copy + Zero + Signed + Ord + Bounded> EdmondsKarp<C> for DenseCapacity<C
     }
 
     fn residual_capacity(&self, from: usize, to: usize) -> C {
-        self.residuals[&(from, to)]
+        self.residuals[(from, to)]
     }
 
     fn flow(&self, from: usize, to: usize) -> C {
-        self.flows[&(from, to)]
+        self.flows[(from, to)]
     }
 
     fn flows(&self) -> Vec<((usize, usize), C)> {
@@ -535,14 +535,14 @@ impl<C: Copy + Zero + Signed + Ord + Bounded> EdmondsKarp<C> for DenseCapacity<C
     }
 
     fn add_flow(&mut self, from: usize, to: usize, capacity: C) {
-        self.flows[&(from, to)] = self.flows[&(from, to)] + capacity;
-        self.flows[&(to, from)] = self.flows[&(to, from)] - capacity;
-        self.residuals[&(from, to)] = self.residuals[&(from, to)] - capacity;
-        self.residuals[&(to, from)] = self.residuals[&(to, from)] + capacity;
+        self.flows[(from, to)] = self.flows[(from, to)] + capacity;
+        self.flows[(to, from)] = self.flows[(to, from)] - capacity;
+        self.residuals[(from, to)] = self.residuals[(from, to)] - capacity;
+        self.residuals[(to, from)] = self.residuals[(to, from)] + capacity;
     }
 
     fn add_residual_capacity(&mut self, from: usize, to: usize, capacity: C) {
-        self.residuals[&(from, to)] = self.residual_capacity(from, to) + capacity;
+        self.residuals[(from, to)] = self.residual_capacity(from, to) + capacity;
     }
 
     fn flows_from(&self, from: usize) -> Vec<usize> {

--- a/src/kuhn_munkres.rs
+++ b/src/kuhn_munkres.rs
@@ -39,7 +39,7 @@ impl<C: Copy> Weights<C> for Matrix<C> {
 
     #[must_use]
     fn at(&self, row: usize, col: usize) -> C {
-        self[&(row, col)]
+        self[(row, col)]
     }
 
     #[must_use]

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -242,7 +242,7 @@ impl<C> Matrix<C> {
     /// let matrix = Matrix::from_rows(input.lines().map(|l| l.chars()))?;
     /// assert_eq!(matrix.rows, 2);
     /// assert_eq!(matrix.columns, 3);
-    /// assert_eq!(matrix[&(1, 1)], 'e');
+    /// assert_eq!(matrix[(1, 1)], 'e');
     /// # Ok::<_, MatrixFormatError>(())
     /// ```
     pub fn from_rows<IR, IC>(rows: IR) -> Result<Self, MatrixFormatError>
@@ -287,7 +287,7 @@ impl<C> Matrix<C> {
     ///
     /// This function panics if the coordinates do not designated a cell.
     #[must_use]
-    pub fn idx(&self, i: &(usize, usize)) -> usize {
+    pub fn idx(&self, i: (usize, usize)) -> usize {
         assert!(
             i.0 < self.rows,
             "trying to access row {} (max {})",
@@ -474,17 +474,17 @@ impl<C> Matrix<C> {
     }
 }
 
-impl<'a, C> Index<&'a (usize, usize)> for Matrix<C> {
+impl<C> Index<(usize, usize)> for Matrix<C> {
     type Output = C;
 
     #[must_use]
-    fn index(&self, index: &'a (usize, usize)) -> &C {
+    fn index(&self, index: (usize, usize)) -> &C {
         &self.data[self.idx(index)]
     }
 }
 
-impl<'a, C> IndexMut<&'a (usize, usize)> for Matrix<C> {
-    fn index_mut(&mut self, index: &'a (usize, usize)) -> &mut C {
+impl<C> IndexMut<(usize, usize)> for Matrix<C> {
+    fn index_mut(&mut self, index: (usize, usize)) -> &mut C {
         let i = self.idx(index);
         &mut self.data[i]
     }

--- a/tests/dijkstra-all.rs
+++ b/tests/dijkstra-all.rs
@@ -7,7 +7,7 @@ fn build_network(size: usize) -> Matrix<usize> {
     for a in 0..size {
         for b in 0..size {
             if rng.gen_ratio(2, 3) {
-                network[&(a, b)] = rng.gen::<u16>() as usize;
+                network[(a, b)] = rng.gen::<u16>() as usize;
             }
         }
     }
@@ -17,7 +17,7 @@ fn build_network(size: usize) -> Matrix<usize> {
 fn neighbours(network: Matrix<usize>) -> impl FnMut(&usize) -> Vec<(usize, usize)> {
     move |&a| {
         (0..network.rows)
-            .filter_map(|b| match network[&(a, b)] {
+            .filter_map(|b| match network[(a, b)] {
                 0 => None,
                 p => Some((b, p)),
             })

--- a/tests/matrix.rs
+++ b/tests/matrix.rs
@@ -5,20 +5,20 @@ use pathfinding::{matrix, matrix::Matrix, utils::absdiff};
 #[test]
 fn sm() {
     let mut m = Matrix::new(2, 2, 0usize);
-    m[&(0, 0)] = 0;
-    m[&(0, 1)] = 1;
-    m[&(1, 0)] = 10;
-    m[&(1, 1)] = 11;
-    m[&(0, 1)] = 2;
-    assert_eq!(m[&(0, 0)], 0);
-    assert_eq!(m[&(0, 1)], 2);
-    assert_eq!(m[&(1, 0)], 10);
-    assert_eq!(m[&(1, 1)], 11);
+    m[(0, 0)] = 0;
+    m[(0, 1)] = 1;
+    m[(1, 0)] = 10;
+    m[(1, 1)] = 11;
+    m[(0, 1)] = 2;
+    assert_eq!(m[(0, 0)], 0);
+    assert_eq!(m[(0, 1)], 2);
+    assert_eq!(m[(1, 0)], 10);
+    assert_eq!(m[(1, 1)], 11);
     m.fill(33);
-    assert_eq!(m[&(0, 0)], 33);
-    assert_eq!(m[&(0, 1)], 33);
-    assert_eq!(m[&(1, 0)], 33);
-    assert_eq!(m[&(1, 1)], 33);
+    assert_eq!(m[(0, 0)], 33);
+    assert_eq!(m[(0, 1)], 33);
+    assert_eq!(m[(1, 0)], 33);
+    assert_eq!(m[(1, 1)], 33);
 }
 
 #[test]
@@ -27,12 +27,12 @@ fn from_vec() {
     assert_eq!(m.rows, 2);
     assert_eq!(m.columns, 3);
     assert!(!m.is_square());
-    assert_eq!(m[&(0, 0)], 10);
-    assert_eq!(m[&(0, 1)], 20);
-    assert_eq!(m[&(0, 2)], 30);
-    assert_eq!(m[&(1, 0)], 40);
-    assert_eq!(m[&(1, 1)], 50);
-    assert_eq!(m[&(1, 2)], 60);
+    assert_eq!(m[(0, 0)], 10);
+    assert_eq!(m[(0, 1)], 20);
+    assert_eq!(m[(0, 2)], 30);
+    assert_eq!(m[(1, 0)], 40);
+    assert_eq!(m[(1, 1)], 50);
+    assert_eq!(m[(1, 2)], 60);
 }
 
 #[test]
@@ -43,10 +43,10 @@ fn from_vec_error() {
 #[test]
 fn to_vec() {
     let mut m = Matrix::new(2, 2, 0usize);
-    m[&(0, 0)] = 0;
-    m[&(0, 1)] = 1;
-    m[&(1, 0)] = 10;
-    m[&(1, 1)] = 11;
+    m[(0, 0)] = 0;
+    m[(0, 1)] = 1;
+    m[(1, 0)] = 10;
+    m[(1, 1)] = 11;
     assert_eq!(m.to_vec(), vec![0, 1, 10, 11]);
 }
 
@@ -56,10 +56,10 @@ fn square_from_vec() {
     assert_eq!(m.rows, 2);
     assert_eq!(m.columns, 2);
     assert!(m.is_square());
-    assert_eq!(m[&(0, 0)], 10);
-    assert_eq!(m[&(0, 1)], 20);
-    assert_eq!(m[&(1, 0)], 30);
-    assert_eq!(m[&(1, 1)], 40);
+    assert_eq!(m[(0, 0)], 10);
+    assert_eq!(m[(0, 1)], 20);
+    assert_eq!(m[(1, 0)], 30);
+    assert_eq!(m[(1, 1)], 40);
 }
 
 #[test]
@@ -255,7 +255,7 @@ fn empty_extend() {
     let mut i = 0;
     for row in 0..m.rows {
         for column in 0..m.columns {
-            assert_eq!(m[&(row, column)], i);
+            assert_eq!(m[(row, column)], i);
             i += 1;
         }
     }
@@ -276,7 +276,7 @@ fn matrix_macro() {
     let mut i = 0;
     for row in 0..m.rows {
         for column in 0..m.columns {
-            assert_eq!(m[&(row, column)], i);
+            assert_eq!(m[(row, column)], i);
             i += 1;
         }
     }


### PR DESCRIPTION
This looks more natural this way:

    matrix[(1, 2)]

instead of

    matrix[&(1, 2)]

This is a semver incompatible change which requires bumping the
major version.
