### PR TITLE
Remove unused uninit/assume_init on Matrix

### DIFF
--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -8,7 +8,6 @@ use itertools::Itertools;
 use num_traits::Signed;
 use std::collections::BTreeSet;
 use std::iter::FusedIterator;
-use std::mem::MaybeUninit;
 use std::ops::{Deref, DerefMut, Index, IndexMut, Neg, Range};
 use std::slice::{Iter, IterMut};
 use thiserror::Error;
@@ -230,20 +229,6 @@ impl<C> Matrix<C> {
             columns,
             data: values,
         })
-    }
-
-    /// Construct a new Matrix with uninitialized content.
-    pub fn new_uninit(rows: usize, columns: usize) -> Matrix<MaybeUninit<C>> {
-        let data_len = rows * columns;
-        let mut data = Vec::with_capacity(data_len);
-        unsafe {
-            data.set_len(data_len);
-        }
-        Matrix {
-            rows,
-            columns,
-            data,
-        }
     }
 
     /// Create new square matrix from vector values. The first value
@@ -633,23 +618,6 @@ impl<C> Matrix<C> {
             self.neighbours(n, diagonals).filter(move |&n| predicate(n))
         })
         .collect()
-    }
-}
-
-impl<C> Matrix<MaybeUninit<C>> {
-    /// Convert to `Matrix<C>`.
-    ///
-    /// # Safety
-    ///
-    /// As with [`MaybeUninit::assume_init()`], it is up to the caller to guarantee
-    /// that the value really is in an initialized state. Calling this when the content
-    /// is not yet fully initialized causes immediate undefined behavior.
-    pub unsafe fn assume_init(self) -> Matrix<C> {
-        Matrix {
-            rows: self.rows,
-            columns: self.columns,
-            data: std::mem::transmute(self.data),
-        }
     }
 }
 

--- a/tests/matrix.rs
+++ b/tests/matrix.rs
@@ -575,23 +575,6 @@ fn in_direction() {
 }
 
 #[test]
-fn uninit() {
-    struct NonClonable(usize);
-    let mut mat = Matrix::<NonClonable>::new_uninit(3, 3);
-    for row in 0..mat.rows {
-        for column in 0..mat.columns {
-            mat[(row, column)].write(NonClonable(3 * row + column));
-        }
-    }
-    let mat = unsafe { mat.assume_init() };
-    for row in 0..mat.rows {
-        for column in 0..mat.columns {
-            assert_eq!(mat[(row, column)].0, row * 3 + column);
-        }
-    }
-}
-
-#[test]
 fn map() {
     let m = Matrix::new(3, 3, 10);
     let m = m.map({


### PR DESCRIPTION
The `Vec<C>` and `Vec<MaybeUninit<C>>` don't have any long-term
guarantee of having the same in-memory representation.
