### PR TITLE
Fix a bug in the implementation of Yen's algorithm

### DIFF
--- a/src/directed/yen.rs
+++ b/src/directed/yen.rs
@@ -172,8 +172,13 @@ where
                 }
             }
         }
-        if let Some(k_route) = k_routes.pop() {
-            routes.push(k_route.0);
+        while let Some(k_route) = k_routes.pop() {
+            if k_route.0.cost > routes[ki].cost {
+                // Pick the route with the smallest cost
+                // that is bigger than the last cost.
+                routes.push(k_route.0);
+                break;
+            }
         }
     }
 

--- a/tests/yen.rs
+++ b/tests/yen.rs
@@ -44,8 +44,8 @@ fn ask_more_than_exist() {
         10,
     );
 
-    // we asked for 10 but the graph can only produce 7
-    assert_eq!(result.len(), 7);
+    // we asked for 10 but the graph can only produce 4
+    assert_eq!(result.len(), 4);
 }
 
 /// Test that we return None in case there is no solution


### PR DESCRIPTION
The function yen was returning different routes with the same cost.
For example, it was returning, for k = 3 (and a example graph):
(a -> b -> c, 3)
(a -> d -> c, 3)
(a -> e -> c, 3)
Instead of:
(a -> b -> c, 3)
(a -> b -> d -> c, 4)
(a -> b -> d -> e -> c, 5)

Fixes #353.