### PR TITLE
remove vecdeque from bfs

### DIFF
--- a/src/directed/bfs.rs
+++ b/src/directed/bfs.rs
@@ -90,12 +90,10 @@ where
     if check_first && success(start) {
         return Some(vec![start.clone()]);
     }
-    let mut to_see = VecDeque::new();
+    let mut i = 0;
     let mut parents: FxIndexMap<N, usize> = FxIndexMap::default();
-    to_see.push_back(0);
     parents.insert(start.clone(), usize::max_value());
-    while let Some(i) = to_see.pop_front() {
-        let node = parents.get_index(i).unwrap().0;
+    while let Some((node, _)) = parents.get_index(i) {
         for successor in successors(node) {
             if success(&successor) {
                 let mut path = reverse_path(&parents, |&p| p, i);
@@ -103,10 +101,10 @@ where
                 return Some(path);
             }
             if let Vacant(e) = parents.entry(successor) {
-                to_see.push_back(e.index());
                 e.insert(i);
             }
         }
+        i += 1;
     }
     None
 }

--- a/src/directed/mod.rs
+++ b/src/directed/mod.rs
@@ -13,11 +13,12 @@ pub mod strongly_connected_components;
 pub mod topological_sort;
 pub mod yen;
 
-use indexmap::IndexMap;
+use indexmap::{IndexMap, IndexSet};
 use rustc_hash::FxHasher;
 use std::hash::{BuildHasherDefault, Hash};
 
 type FxIndexMap<K, V> = IndexMap<K, V, BuildHasherDefault<FxHasher>>;
+type FxIndexSet<K> = IndexSet<K, BuildHasherDefault<FxHasher>>;
 
 #[allow(clippy::needless_collect)]
 fn reverse_path<N, V, F>(parents: &FxIndexMap<N, V>, mut parent: F, start: usize) -> Vec<N>


### PR DESCRIPTION
It's my understanding that bfs always goes through nodes in the order they are found. I added a `dbg!(i)` to the loop and saw it was always consecutive. This makes me believe that the VecDeque is unnecessary here.

For some reason however, this adds a 40% regression to the benchmarks in this crate. I'm investigating why that might be the case, since as far as I've been able to test, this change makes no algorithmic behavior changes