### PR TITLE
Clarify ordering of coordinate tuples

### DIFF
--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -14,6 +14,8 @@ use thiserror::Error;
 /// Matrix of an arbitrary type. Data are stored consecutively in
 /// memory, by rows. Raw data can be accessed using `as_ref()`
 /// or `as_mut()`.
+///
+/// Coordinates within the matrix are represented as (row, column) tuples
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Matrix<C> {
     /// Rows


### PR DESCRIPTION
My first try using `pathfinding` took longer than expected because I assumed coordinates were in `(x, y)` order, not `(y, x)` aka `(row, col)` order. It's clear after reading a bit more of the documentation and code, but I thought it might be beneficial to make it explicit in the docs.