### PR TITLE
Implement Matrix::items()

### DIFF
--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -563,6 +563,11 @@ impl<C> Matrix<C> {
         self.data.iter_mut()
     }
 
+    /// Return an iterator on the Matrix coordinates and values
+    pub fn items(&self) -> impl Iterator<Item = ((usize, usize), &C)> {
+        self.indices().zip(self.values())
+    }
+
     /// Return a set of the indices reachable from a candidate starting point
     /// and for which the given predicate is valid. This can be used for example
     /// to implement a flood-filling algorithm. Since the indices are collected

--- a/tests/matrix.rs
+++ b/tests/matrix.rs
@@ -625,3 +625,10 @@ fn map() {
         Matrix::square_from_vec(vec![11, 12, 13, 14, 15, 16, 17, 18, 19]).unwrap()
     );
 }
+
+#[test]
+fn items() {
+    let m = matrix![[0, 1, 2], [3, 4, 5], [6, 7, 8]];
+
+    assert_eq!(m.items().find(|&(_, val)| val == &3), Some(((1, 0), &3)));
+}


### PR DESCRIPTION
I wanted to find a good way to find coordinates in the Matrix with specific values.

My initial approach was something like this:
```rust
    let idx = m
        .values()
        .enumerate()
        .find(|(_, &v| v == needle)
        .unwrap()
        .0;

    let pos = (idx / m.columns, idx % m.columns);
```

Then I realized I could simplify to this:
```rust
    let pos = m
        .indices()
        .zip(g.values())
        .find(|(_, &v)| v == needle)
        .unwrap()
        .0;
```

If this is a common pattern, then this could be simplified further to
```rust
 let pos = m
        .items()
        .find(|&(_, v)| v == &needle)
        .unwrap()
        .0;
```
Maybe this could be a standard API? 

