### PR TITLE
Allow creating a Matrix based on a function from position to value

### DIFF
--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -45,6 +45,30 @@ impl<C: Clone> Matrix<C> {
         }
     }
 
+    /// Create new matrix with each cell's initial value given by a
+    /// function of its position.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if the number of rows is greater than 0
+    /// and the number of columns is 0. If you need to build a matrix
+    /// column by column, build it row by row and call transposition
+    /// or rotation functions on it.
+    pub fn from_fn(rows: usize, columns: usize, cb: impl FnMut((usize, usize)) -> C) -> Self {
+        assert!(
+            rows == 0 || columns > 0,
+            "unable to create a matrix with empty rows"
+        );
+        Self {
+            rows,
+            columns,
+            data: (0..rows)
+                .flat_map(move |row| (0..columns).map(move |column| (row, column)))
+                .map(cb)
+                .collect(),
+        }
+    }
+
     /// Create new square matrix with initial value.
     pub fn new_square(size: usize, value: C) -> Self {
         Self::new(size, size, value)

--- a/tests/matrix.rs
+++ b/tests/matrix.rs
@@ -22,6 +22,20 @@ fn sm() {
 }
 
 #[test]
+fn from_fn() {
+    let m = Matrix::from_fn(2, 3, |(row, column)| 10 * row + column);
+    assert_eq!(m.rows, 2);
+    assert_eq!(m.columns, 3);
+    assert!(!m.is_square());
+    assert_eq!(m[(0, 0)], 0);
+    assert_eq!(m[(0, 1)], 1);
+    assert_eq!(m[(0, 2)], 2);
+    assert_eq!(m[(1, 0)], 10);
+    assert_eq!(m[(1, 1)], 11);
+    assert_eq!(m[(1, 2)], 12);
+}
+
+#[test]
 fn from_vec() {
     let m = Matrix::from_vec(2, 3, vec![10, 20, 30, 40, 50, 60]).unwrap();
     assert_eq!(m.rows, 2);


### PR DESCRIPTION
I ended up wanting to create a Matrix this way the very first time I used `pathfinding`, so here's the code for it in case you think it would make sense to add back to the library. It doesn't add any fundamentally new capabilities, but it seems like a pretty natural convenience to have. It's a small enough change that I figured it would hopefully be okay to skip creating an issue first.